### PR TITLE
Add metadata display for product case studies

### DIFF
--- a/web/src/app/components/ProjectMetadata.tsx
+++ b/web/src/app/components/ProjectMetadata.tsx
@@ -1,0 +1,188 @@
+'use client';
+
+import React, { useState, useEffect, useRef } from 'react';
+
+interface ProjectMetadataProps {
+  metadata: Record<string, string | string[]>;
+  showDate?: boolean;
+}
+
+const ProjectMetadata: React.FC<ProjectMetadataProps> = ({ metadata, showDate = false }) => {
+  const [showSideMetadata, setShowSideMetadata] = useState(false);
+  const mainMetadataRef = useRef<HTMLDivElement>(null);
+  
+  // Process metadata and group values by key
+  const processedMetadata: Record<string, string[]> = {};
+  
+  Object.entries(metadata).forEach(([key, value]) => {
+    // Skip id and title keys
+    if (key === 'id' || key === 'title') return;
+    
+    // Initialize the array if it doesn't exist
+    if (!processedMetadata[key]) {
+      processedMetadata[key] = [];
+    }
+    
+    // Add value(s) to the array, splitting any values containing commas
+    if (Array.isArray(value)) {
+      // For each array item, split by comma and trim whitespace
+      value.forEach(item => {
+        if (typeof item === 'string' && item.includes(',')) {
+          const splitItems = item.split(',').map(part => part.trim());
+          processedMetadata[key].push(...splitItems);
+        } else {
+          processedMetadata[key].push(item);
+        }
+      });
+    } else if (typeof value === 'string') {
+      // Split string value by comma and trim whitespace
+      if (value.includes(',')) {
+        const splitItems = value.split(',').map(part => part.trim());
+        processedMetadata[key].push(...splitItems);
+      } else {
+        processedMetadata[key].push(value);
+      }
+    }
+  });
+
+  // Define column mappings
+  const column1Keys = ['work', 'team', 'special thanks'];
+  const column2Keys = ['discipline'];
+  const column3Keys = ['tech stack'];
+  
+  // Define display names for keys (for custom labels)
+  const displayNames: Record<string, string> = {
+    'tech stack': 'tools & tech stack'
+  };
+  
+  // Organize metadata by columns
+  const columns = [
+    { 
+      id: 'column1', 
+      items: Object.entries(processedMetadata)
+        .filter(([key]) => column1Keys.includes(key))
+        .map(([key, values]) => ({ key, values }))
+        .sort((a, b) => column1Keys.indexOf(a.key) - column1Keys.indexOf(b.key))
+    },
+    { 
+      id: 'column2', 
+      items: Object.entries(processedMetadata)
+        .filter(([key]) => column2Keys.includes(key))
+        .map(([key, values]) => ({ key, values }))
+    },
+    { 
+      id: 'column3', 
+      items: Object.entries(processedMetadata)
+        .filter(([key]) => column3Keys.includes(key))
+        .map(([key, values]) => ({ key, values }))
+    }
+  ];
+
+  // Scroll handler to show/hide side metadata
+  useEffect(() => {
+    const handleScroll = () => {
+      if (mainMetadataRef.current) {
+        const { top, bottom } = mainMetadataRef.current.getBoundingClientRect();
+        
+        // Show side metadata when 75% of the main metadata is scrolled out of view
+        // This creates a smoother transition and ensures the side metadata appears
+        // when the user has meaningfully scrolled past the original metadata
+        const triggerPoint = window.innerHeight * 0.25;
+        setShowSideMetadata(top < triggerPoint && bottom < triggerPoint);
+      }
+    };
+
+    window.addEventListener('scroll', handleScroll);
+    handleScroll(); // Check initial scroll position
+    
+    return () => window.removeEventListener('scroll', handleScroll);
+  }, []);
+
+  // Render metadata content for main display (in columns)
+  const renderMainMetadataContent = () => (
+    <>
+      {columns.map((column) => (
+        <div key={column.id}>
+          {column.items.map((item) => (
+            <div key={item.key} className="mb-4">
+              <div className="font-[family-name:var(--font-diatype-mono)] text-gray-500 mb-1 uppercase tracking-wide text-xs">
+                {displayNames[item.key] || item.key}
+              </div>
+              <div className="font-[family-name:var(--font-fragment-sans)]">
+                {item.values.map((value, index) => (
+                  <div key={index} className="leading-relaxed">{value}</div>
+                ))}
+              </div>
+            </div>
+          ))}
+        </div>
+      ))}
+    </>
+  );
+  
+  // Render metadata content for side panel (flat list)
+  const renderSideMetadataContent = () => {
+    // Get all metadata items across all columns
+    const allItems = columns.flatMap(column => column.items);
+    
+    // Sort them in a specific order
+    const orderedItems = [
+      ...allItems.filter(item => item.key === 'work'),
+      ...allItems.filter(item => item.key === 'team'),
+      ...allItems.filter(item => item.key === 'special thanks'),
+      ...allItems.filter(item => item.key === 'discipline'),
+      ...allItems.filter(item => item.key === 'tech stack'),
+    ];
+    
+    return (
+      <>
+        {orderedItems.map((item) => (
+          <div key={item.key} className="mb-4">
+            <div className="font-[family-name:var(--font-diatype-mono)] text-gray-500 mb-1 uppercase tracking-wide text-xs">
+              {displayNames[item.key] || item.key}
+            </div>
+            <div className="font-[family-name:var(--font-fragment-sans)]">
+              {item.values.map((value, index) => (
+                <div key={index} className="leading-relaxed">{value}</div>
+              ))}
+            </div>
+          </div>
+        ))}
+      </>
+    );
+  };
+
+  return (
+    <>
+      {/* Main metadata (original position) - date is now displayed outside this component */}
+      <div ref={mainMetadataRef} className="mb-8 text-sm grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-x-6 gap-y-4">
+        {renderMainMetadataContent()}
+      </div>
+
+      {/* Side metadata (right side when scrolled) */}
+      <div 
+        className={`fixed right-8 top-24 hidden xl:block z-20 w-64 p-5 border-l border-gray-200 bg-white/80
+                  transition-all duration-300 transform ${showSideMetadata ? 'opacity-100 translate-x-0' : 'opacity-0 translate-x-8 pointer-events-none'}`}
+      >
+        <div className="text-xs grid grid-cols-1 gap-y-4 max-h-[80vh] overflow-y-auto pr-2">
+          {/* Date at the top of side metadata as first item */}
+          {showDate && (
+            <div className="mb-4">
+              <div className="font-[family-name:var(--font-diatype-mono)] text-gray-500 mb-1 uppercase tracking-wide text-xs">
+                date
+              </div>
+              <div className="font-[family-name:var(--font-fragment-sans)]">
+                <div className="leading-relaxed">{(metadata.date as string)}</div>
+              </div>
+            </div>
+          )}
+          
+          {/* Rest of metadata items in a flat list */}
+          {renderSideMetadataContent()}
+        </div>
+      </div>
+    </>
+  );
+};
+
+export default ProjectMetadata;

--- a/web/src/app/components/TableOfContents.tsx
+++ b/web/src/app/components/TableOfContents.tsx
@@ -72,7 +72,7 @@ const TableOfContents: React.FC<TableOfContentsProps> = () => {
   }
 
   return (
-    <div className="fixed left-8 top-48 hidden lg:block overflow-y-auto max-h-[60vh] z-10 w-40">
+    <div className="fixed left-8 top-48 hidden lg:block overflow-y-auto max-h-[60vh] z-10 w-56 lg:pr-8 xl:pr-4">
       <nav className="toc text-xs font-[family-name:var(--font-fragment-sans)]" aria-label="Table of contents">
         <ul className="space-y-1 text-gray-500">
           {headings.map(heading => (

--- a/web/src/app/projects/[id]/page.tsx
+++ b/web/src/app/projects/[id]/page.tsx
@@ -11,6 +11,7 @@ import ZoomableImage from '@/app/components/ZoomableImage';
 import ClientTOC from '@/app/components/ClientTOC';
 import ProgressWrapper from '@/app/components/ProgressWrapper';
 import VimeoWrapper from '@/app/components/VimeoWrapper';
+import ProjectMetadata from '@/app/components/ProjectMetadata';
 
 // Custom Markdown components
 const MarkdownImage = ({ alt, src }: { alt?: string; src?: string }) => {
@@ -43,13 +44,13 @@ async function getProjectContent(id: string) {
   const paddedId = id.padStart(2, '0');
   
   // Try first from product folder
-  const filePath = path.join(process.cwd(), 'src/app/data/product/projects', paddedId, 'study.md');
+  const productPath = path.join(process.cwd(), 'src/app/data/product/projects', paddedId, 'study.md');
   
   try {
-    console.log(`Attempting to read file at: ${filePath}`);
-    const fileContent = fs.readFileSync(filePath, 'utf8');
+    console.log(`Attempting to read file at: ${productPath}`);
+    const fileContent = fs.readFileSync(productPath, 'utf8');
     const { content, data } = matter(fileContent);
-    return { content, frontmatter: data };
+    return { content, frontmatter: data, source: 'product' };
   } catch (error) {
     // If file not found, try the legacy path
     try {
@@ -57,7 +58,7 @@ async function getProjectContent(id: string) {
       console.log(`Attempting to read file at legacy path: ${legacyPath}`);
       const fileContent = fs.readFileSync(legacyPath, 'utf8');
       const { content, data } = matter(fileContent);
-      return { content, frontmatter: data };
+      return { content, frontmatter: data, source: 'legacy' };
     } catch (legacyError) {
       console.error(`Error reading project file: ${error}`);
       console.error(`Error reading legacy project file: ${legacyError}`);
@@ -124,10 +125,7 @@ export default async function ProjectPage(props: ProjectPageProps) {
             href="/" 
             className="text-gray-400 hover:text-gray-700 transition-colors duration-200 flex items-center group"
           >
-            <span className="text-xl inline-block mr-2 transform group-hover:-translate-x-1 transition-transform duration-200 font-[family-name:var(--font-diatype-mono)]">←</span>
-            <span className="font-[family-name:var(--font-glare)] text-sm">
-              {parseInt(project.id.toString()) < 10 ? `0${project.id}` : project.id}
-            </span>
+            <span className="text-xl inline-block transform group-hover:-translate-x-1 transition-transform duration-200 font-[family-name:var(--font-diatype-mono)]">←</span>
           </Link>
         </div>
         
@@ -135,23 +133,32 @@ export default async function ProjectPage(props: ProjectPageProps) {
         <ClientTOC projectId={project.id} />
         
         {/* Main content with left-aligned text */}
-        <div className="container mx-auto px-4 py-8 md:py-16 max-w-3xl">
+        <div className="container mx-auto px-4 py-8 md:py-16 max-w-3xl lg:pl-24">
           {/* Mobile back button (only visible on small/medium screens) */}
           <div className="mb-6 lg:hidden">
             <Link 
               href="/" 
               className="text-gray-500 hover:text-gray-700 transition-colors duration-200 flex items-center group"
             >
-              <span className="inline-block mr-2 transform group-hover:-translate-x-1 transition-transform duration-200 font-[family-name:var(--font-diatype-mono)]">←</span>
-              <span className="font-[family-name:var(--font-glare)]">
-                {parseInt(project.id.toString()) < 10 ? `0${project.id}` : project.id}
-              </span>
+              <span className="inline-block transform group-hover:-translate-x-1 transition-transform duration-200 font-[family-name:var(--font-diatype-mono)]">←</span>
             </Link>
           </div>
           
-          <h1 className="text-4xl md:text-5xl font-[family-name:var(--font-glare)] mb-8">
+          {/* Display date for product projects if available */}
+          {projectData.source === 'product' && projectData.frontmatter && projectData.frontmatter.date && (
+            <div className="mb-2 font-[family-name:var(--font-diatype-mono)] tracking-widest text-xs uppercase text-gray-600 font-medium">
+              {(projectData.frontmatter.date as string).toUpperCase()}
+            </div>
+          )}
+          
+          <h1 className="text-4xl md:text-5xl font-[family-name:var(--font-glare)] mb-6">
             {project.name}
           </h1>
+          
+          {/* Display metadata only for product projects */}
+          {projectData.source === 'product' && projectData.frontmatter && (
+            <ProjectMetadata metadata={projectData.frontmatter} showDate={true} />
+          )}
         
         <div className="prose prose-lg max-w-none">
           <Markdown


### PR DESCRIPTION
- Create ProjectMetadata component for displaying case study metadata
- Display metadata in columns with consistent styling
- Show date above title for cleaner design
- Add sticky side metadata panel that appears on scroll for larger screens
- Adjust table of contents spacing for better readability

🤖 Generated with [Claude Code](https://claude.ai/code)